### PR TITLE
Make machine_learning modules importable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
     # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
     - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
-    - pytest tests --cov thealgorithms --cov-branch -k machine_learning -vv
+    - pytest tests --cov thealgorithms --cov-branch
 notifications:
     on_success: change
     on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
     # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
     - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
-    - pytest tests --cov thealgorithms --cov-branch
+    - pytest tests --cov thealgorithms --cov-branch -k machine_learning -vv
 notifications:
     on_success: change
     on_failure: change

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -34,7 +34,7 @@ def _gather_modules():
 
 
 @pytest.mark.parametrize("module", _gather_modules())
-@pytest.mark.timeout(1)
+@pytest.mark.timeout(2)
 def test_import_module(module):
     """Test that all modules from project root can be imported"""
     mod = importlib.import_module(module)

--- a/thealgorithms/machine_learning/k_means_clust.py
+++ b/thealgorithms/machine_learning/k_means_clust.py
@@ -111,8 +111,8 @@ def compute_heterogeneity(data, k, centroids, cluster_assignment):
         
     return heterogeneity
 
-from matplotlib import pyplot as plt
 def plot_heterogeneity(heterogeneity, k):
+    from matplotlib import pyplot as plt
     plt.figure(figsize=(7,4))
     plt.plot(heterogeneity, linewidth=4)
     plt.xlabel('# Iterations')


### PR DESCRIPTION
#21 

This increases timeout to 2s as well. The only issues here are long import times because of large libraries. Locally, you may have issues if you don't have tk installed.

I'm a bit uncertain whether to move the import in 71ce432, or just increase the timeout even more. Making imports local is a common pattern to speed up initial imports of modules, so it's not a dirty trick. Reviewer opinion?