### PR TITLE
Test out of place sorting

### DIFF
--- a/sorts/bucket_sort.py
+++ b/sorts/bucket_sort.py
@@ -21,7 +21,7 @@ DEFAULT_BUCKET_SIZE = 5
 
 def bucketSort(myList, bucketSize=DEFAULT_BUCKET_SIZE):
     if(len(myList) == 0):
-        print('You don\'t have any elements in array!')
+        return []
 
     minValue = myList[0]
     maxValue = myList[0]

--- a/sorts/merge_sort_fastest.py
+++ b/sorts/merge_sort_fastest.py
@@ -4,16 +4,17 @@ Takes an average of 0.6 microseconds to sort a list of length 1000 items.
 Best Case Scenario : O(n)
 Worst Case Scenario : O(n)
 '''
-def merge_sort(LIST):
+def merge_sort(lst):
+    lst = list(lst) # copy argument to avoid wrecking it
     start = []
     end = []
-    while len(LIST) > 1:
-        a = min(LIST)
-        b = max(LIST)
+    while len(lst) > 1:
+        a = min(lst)
+        b = max(lst)
         start.append(a)
         end.append(b)
-        LIST.remove(a)
-        LIST.remove(b)
-    if LIST: start.append(LIST[0])
+        lst.remove(a)
+        lst.remove(b)
+    if lst: start.append(lst[0])
     end.reverse()
     return (start + end)

--- a/sorts/tree_sort.py
+++ b/sorts/tree_sort.py
@@ -1,15 +1,16 @@
 # Tree_sort algorithm
 # Build a BST and in order traverse.
 
-class node():
+
+class node:
     # BST data structure
     def __init__(self, val):
         self.val = val
-        self.left = None 
-        self.right = None 
-    
-    def insert(self,val):
-        if self.val:
+        self.left = None
+        self.right = None
+
+    def insert(self, val):
+        if self.val is not None:
             if val < self.val:
                 if self.left is None:
                     self.left = node(val)
@@ -20,26 +21,31 @@ class node():
                     self.right = node(val)
                 else:
                     self.right.insert(val)
-        else:
-            self.val = val
+            else:  # duplicate value, displace tree left
+                new_left = node(val)
+                new_left.left = self.left
+                self.left = new_left
+
 
 def inorder(root, res):
-    # Recursive travesal 
+    # Recursive travesal
     if root:
-        inorder(root.left,res)
+        inorder(root.left, res)
         res.append(root.val)
-        inorder(root.right,res)
+        inorder(root.right, res)
+
 
 def treesort(arr):
     # Build BST
     if len(arr) == 0:
-        return arr
+        return []
     root = node(arr[0])
-    for i in range(1,len(arr)):
+    for i in range(1, len(arr)):
         root.insert(arr[i])
-    # Traverse BST in order. 
+    # Traverse BST in order.
     res = []
-    inorder(root,res)
+    inorder(root, res)
     return res
 
-print(treesort([10,1,3,2,9,14,13]))
+
+print(treesort([10, 1, 3, 2, 9, 14, 13]))

--- a/tests/sorts/conftest.py
+++ b/tests/sorts/conftest.py
@@ -1,0 +1,28 @@
+"""This file contains some pytest fixtures that are usable throughout the tests
+in this directory, and any subdirectory.
+
+Read more about fixtures here: https://docs.pytest.org/en/latest/fixture.html
+"""
+import random
+
+import pytest
+
+
+@pytest.fixture
+def randlist():
+    """Return a function that deterministically creates a list of random
+    elements.
+    """
+
+    def _randlist(num_elems=1000, min_=-500, max_=500):
+        """Return a list of random elements.
+
+        Calling this function several times with the same arguments always
+        returns the same list (on any given machine). This is important for
+        test reproducibility.
+        """
+        # Sets a seed to ensure the same number sequence
+        random.seed(52346)
+        return [random.randint(min_, max_) for _ in range(num_elems)]
+
+    return _randlist

--- a/tests/sorts/test_out_of_place_sorts.py
+++ b/tests/sorts/test_out_of_place_sorts.py
@@ -1,0 +1,144 @@
+"""This module tests deterministic out-of-place sorting algorithms in a generic
+fashion by having them sort a few different kinds of lists.
+
+An out-of-place sorting algorithm is expected to return a sorted copy of the
+input. In general, it should not mutate the input. The tests in this module
+expects this generic behavior. The built-in ``sorted`` function is an example
+of an out-of-place sorting algorithm:
+
+    >>> lst = [5, 2, 1]
+    >>> sorted_lst = sorted(lst)
+    >>> print(lst)
+    [5, 2, 1] # not mutated
+    >>> print(sorted_lst)
+    [1, 2, 5]
+
+If you implement an out-of-place sorting algorithm, you can run all the tests
+in this test suite on it by simply adding the function to the SORTS list. Note
+that you must import the module in which the sorting algorithm is located as
+well.
+
+Please only add deterministic algorithms here. Random algorithms (e.g.
+bogosort) shouldn't be run on lists this large, as they may never terminate.
+"""
+import pytest
+
+import sorts.bucket_sort
+import sorts.counting_sort
+import sorts.merge_sort_fastest
+import sorts.pancake_sort
+import sorts.timsort
+import sorts.tree_sort
+import sorts.quick_sort
+
+SORTS = [
+    sorts.bucket_sort.bucketSort,
+    sorts.counting_sort.counting_sort,
+    sorts.merge_sort_fastest.merge_sort,
+    sorts.pancake_sort.pancakesort,
+    sorts.timsort.timsort,
+    sorts.tree_sort.treesort,
+    sorts.quick_sort.quick_sort,
+]
+
+# Constants applying to most lists in the tests
+# note that abs(MIN) + abs(MAX) < NUM_ELEMENTS, which
+# guarantees duplicates in test cases.
+NUM_ELEMENTS = 500
+MIN = -int(NUM_ELEMENTS / 3)
+MAX = -int(NUM_ELEMENTS / 3)
+
+
+@pytest.mark.parametrize("sort", SORTS)
+class TestOutOfPlaceSort:
+    """Test class for out-of-place sorting algorithms. Note that the class is just
+    for grouping.
+    
+    Note that the built-in ``sorted`` returns a copy, and does not mutate the
+    input. It's very important to assert against a _copy_ of the list the
+    algorithm sorts, so as not to assert that a list is equal to itself.
+
+    Note that all test cases, except that for the empty list, have lists
+    containing at least some duplicates.
+    """
+
+    @staticmethod
+    def test_does_not_mutate_input(sort, randlist):
+        """Test that the out-of-place sorting algorithm does not mutate the
+        input.
+        """
+        lst = randlist(num_elems=NUM_ELEMENTS, min_=MIN, max_=MAX)
+        expected = list(lst)  # expect lst to be unchanged
+
+        sort(lst)
+
+        assert lst == expected
+
+    @staticmethod
+    def test_sort_random_list(sort, randlist):
+        """Test sorting a list with random elements in random order."""
+        lst = randlist(num_elems=NUM_ELEMENTS, min_=MIN, max_=MAX)
+        expected = sorted(lst)
+
+        actual = sort(lst)
+
+        assert actual == expected
+
+    @staticmethod
+    def test_sort_sorted_list(sort, randlist):
+        """Test sorting a list of random elements which is already sorted in
+        ascending order.
+        """
+        lst = sorted(randlist(num_elems=NUM_ELEMENTS, min_=MIN, max_=MAX))
+        expected = list(lst)
+
+        actual = sort(lst)
+
+        assert actual == expected
+
+    @staticmethod
+    def test_sort_reversed_list(sort, randlist):
+        """Test sorting a list of random elements which is sorted in descending
+        order (reversed).
+        """
+        lst = list(reversed(randlist(num_elems=NUM_ELEMENTS, min_=MIN, max_=MAX)))
+        expected = sorted(lst)
+
+        actual = sort(lst)
+
+        assert actual == expected
+
+    @staticmethod
+    def test_sort_equal_list(sort):
+        """Test sorting a list containing duplicates of a single element."""
+        elem = 37
+        lst = [37 for _ in range(NUM_ELEMENTS)]
+        expected = list(lst)
+
+        actual = sort(lst)
+
+        assert actual == expected
+
+    @staticmethod
+    def test_sort_negative_numbers(sort, randlist):
+        """Test sorting a list containing only negative numbers.
+
+        NOTE: LEGACY TEST
+        At the time of writing this, I don't see why this test would be
+        important, but it was frequent in the original doctests that this test
+        suite replaces, so we keep it. It can very likely be removed with
+        negligible impact on test performance.
+        """
+        lst = randlist(num_elems=NUM_ELEMENTS, min_=MIN, max_=0)
+        expected = sorted(lst)
+
+        actual = sort(lst)
+
+        assert actual == expected
+
+    @staticmethod
+    def test_sort_empty_list(sort):
+        """Test sorting an empty list."""
+        empty_list = []
+        actual = sort(empty_list)
+        assert actual == empty_list


### PR DESCRIPTION
Adds test cases for out-of-place sorting algorithms.

Also fixes `bucket_sort`, `merge_sort_fastest` and `tree_sort`

`timsort` is expected to fail some tests as I did not have time to fix it.

Fix #50 